### PR TITLE
Feature/#12 diff functionality

### DIFF
--- a/dap_api/app/app/backend/ors_processor.py
+++ b/dap_api/app/app/backend/ors_processor.py
@@ -16,12 +16,13 @@ class ORSProcessor(BaseProcessor):
         disaster_areas = {}
         lookup_bbox = self.get_bounding_box(request, options.ors_api, options.ors_profile)
         if options.portal_mode.value == "avoid_areas":
+            # TODO: add filters for areas
             disaster_areas = crud.disaster_area.get_multi_as_feature_collection(db, lookup_bbox)
             coordinates_to_add = [f.geometry.coordinates for f in disaster_areas.features if
                                   f.geometry.type in ["Polygon"]]
             if coordinates_to_add:
                 # ORS expects Polygon coordinates to be a list of lists of coordinates, whilst for MultiPolygon
-                # coordinates is expected to be a list of lists of lists of coordinates. If we get a Polygon in the
+                # coordinates is expected to be a list of lists, of lists of coordinates. If we get a Polygon in the
                 # original request, we need to convert it to a MultiPolygon before adding
                 if request.options.avoid_polygons.type == "Polygon":
                     request.options.avoid_polygons.type = "MultiPolygon"
@@ -41,7 +42,7 @@ class ORSProcessor(BaseProcessor):
         request_dict = self.prepare_request_dic(request)
         request_header = self.prepare_headers(request_dict, options.ors_response_type.value, header_authorization)
 
-        # debug mode: return modified request without relaying to backend
+        # debug mode: return modified request without relaying to backend TODO: log instead
         if request.portal_options.debug:
             return ORSResponse(
                 status_code=200,

--- a/dap_api/app/app/backend/ors_processor.py
+++ b/dap_api/app/app/backend/ors_processor.py
@@ -74,6 +74,9 @@ class ORSProcessor(BaseProcessor):
             if request.portal_options.return_areas_in_response:
                 response_json["disaster_areas"] = json.loads(disaster_areas.json())
                 response_json["disaster_areas_lookup_bbox"] = lookup_bbox
+
+            # add portal options to query
+            response_json['metadata']['query']['portal_options'] = request.portal_options.dict()
             response_body = json.dumps(response_json)
 
         return ORSResponse(

--- a/dap_api/app/app/backend/ors_processor.py
+++ b/dap_api/app/app/backend/ors_processor.py
@@ -6,7 +6,7 @@ from fastapi.responses import JSONResponse
 from app import crud
 from app.backend.base import BaseProcessor
 from app.schemas import ORSRequest, PathOptions, ORSResponse
-from app.backend.geoutil import bbox_buffer_percentage, meters_travelled, bbox_from_radius
+from app.backend.geoutil import bbox_buffer_percentage, meters_travelled, bbox_from_radius, build_diff_query
 
 
 class ORSProcessor(BaseProcessor):
@@ -52,12 +52,25 @@ class ORSProcessor(BaseProcessor):
         # relay to backend
         endpoint = f"/{options.ors_api}/{options.ors_profile}/{options.ors_response_type}"
         response = self.relay_request_post(endpoint, request_header, request_dict)
+        response_json = {}
+        if response.status_code == 200 and request.portal_options.generate_difference:
+            response_json = response.json()
+            new_features = []
+            if "options" in request_dict and "avoid_polygons" in request_dict["options"]:
+                request_dict.get("options").pop("avoid_polygons")
+                response_no_avoid = self.relay_request_post(endpoint, request_header, request_dict)
+
+                new_features = self.calculate_new_features(db, options, request_dict,
+                                                           response_json[result_key(options)],
+                                                           response_no_avoid.json()[result_key(options)])
+            response_json[result_key(options)] = new_features
 
         # process result
         if options.ors_response_type.value == "gpx":
             response_body = response.text
         else:
-            response_json = response.json()
+            if not response_json:
+                response_json = response.json()
             if request.portal_options.return_areas_in_response:
                 response_json["disaster_areas"] = json.loads(disaster_areas.json())
                 response_json["disaster_areas_lookup_bbox"] = lookup_bbox
@@ -68,6 +81,55 @@ class ORSProcessor(BaseProcessor):
             body=response_body,
             media_type=response.headers.get("Content-Type")
         )
+
+    @staticmethod
+    def calculate_new_features(db, options, request_dict, avoid_results, no_avoid_results):
+        out_type = options.ors_response_type.value
+        new_features = []
+        for i, item in enumerate(no_avoid_results):
+            if options.ors_api is "isochrones":
+                avoid_item = ORSProcessor.get_matching_isochrone(avoid_results, item)
+            else:
+                avoid_item = avoid_results[i]
+            # no difference
+            if avoid_item == item:
+                continue
+            query = build_diff_query(avoid_item, item, options.ors_api, out_type)
+            diff_geom = db.execute(query).scalar()
+            avoid_item["geometry"] = json.loads(diff_geom)
+            # no difference
+            if not avoid_item["geometry"]["coordinates"]:
+                continue
+            ORSProcessor.update_info(avoid_item, item, options, request_dict)
+            new_features.append(avoid_item)
+        return new_features
+
+    @staticmethod
+    def get_matching_isochrone(avoid_results, item):
+        # the number of isochrones in the avoid-response can be different from the normal one
+        # thus, they are matched by the group_index and value
+        return next((x for x in avoid_results if
+                     x["properties"]["group_index"] == item["properties"]["group_index"] and
+                     x["properties"]["value"] == item["properties"]["value"]), None)
+
+    @staticmethod
+    def update_info(avoid_item, item, options, request_dict):
+        if options.ors_api == "isochrones":
+            for attribute in request_dict.get("attributes") or []:
+                avoid_item["properties"][attribute] = item.get("properties").get(attribute) - avoid_item.get(
+                    "properties").get(attribute)
+        elif options.ors_api == "directions":
+            item_props = item if options.ors_response_type == "json" else item["properties"]
+            avoid_item_props = avoid_item if options.ors_response_type == "json" else avoid_item["properties"]
+            # recalculate distance and duration
+            avoid_item_props["summary"]["distance"] -= item_props["summary"]["distance"]
+            avoid_item_props["summary"]["duration"] -= item_props["summary"]["duration"]
+            for k, v in avoid_item_props["summary"].items():
+                avoid_item_props["summary"][k] = round(v, 1)
+            # drop unusable properties
+            avoid_item_props.pop("way_points", None)
+            avoid_item_props.pop("segments", None)
+        # TODO: recalculate bbox
 
     @staticmethod
     def get_bounding_box(request: ORSRequest, target_api, target_profile) -> list:
@@ -140,6 +202,13 @@ class ORSProcessor(BaseProcessor):
         if len(header_authorization) > 0:
             request_header["Authorization"] = header_authorization
         return request_header
+
+
+def result_key(options: PathOptions) -> str:
+    """
+    returns the correct key of the result list depending on the response type
+    """
+    return "features" if options.ors_response_type != "json" else "routes"
 
 
 def clean_dict(d):

--- a/dap_api/app/app/schemas/ors_request.py
+++ b/dap_api/app/app/schemas/ors_request.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import Optional, Union, Dict
 
-from pydantic import BaseModel, Extra, conint, conlist
+from pydantic import BaseModel, Extra, conint, conlist, Field
 
 
 class PortalMode(str, Enum):
@@ -41,6 +41,8 @@ class PortalOptions(BaseModel):
     debug: Optional[bool] = False
     return_areas_in_response: Optional[bool] = False
     bounds_looseness: Optional[conint(ge=0, le=200)] = 0
+    generate_difference: Optional[bool] = Field(False, description='Generates difference between requests with and '
+                                                                   'without avoid areas. Uses up 2 ORS requests.')
 
 
 class AvoidPolygons(BaseModel):

--- a/dap_api/app/app/tests/backend/test_geoutil.py
+++ b/dap_api/app/app/tests/backend/test_geoutil.py
@@ -1,0 +1,47 @@
+import pytest
+from app.backend.geoutil import *
+
+
+@pytest.mark.skipif(True, reason="TODO")  # TODO: WIP
+class TestGeoUtil:
+    def test_point_from_point_bearing_distance(self):
+        # point_from_point_bearing_distance()
+        assert False
+
+    def test_point_distance(self):
+        # point_distance()
+        assert False
+
+    def test_bbox_length(self):
+        # bbox_length()
+        assert False
+
+    @pytest.mark.parametrize("lon,out",
+                             [(0, 0), (20.12, 22.12), (-999.00, 81), (999.00, -81), (-180, -180), (180, 180)])
+    def test_restrict_longitude(self, lon: float, out: float):
+        res = restrict_longitude(lon)
+        assert res == out
+
+    def test_restrict_latitude(self):
+        # restrict_latitude()
+        assert False
+
+    def test_bbox_buffer_percentage(self):
+        # bbox_buffer_percentage()
+        assert False
+
+    def test_bbox_from_radius(self):
+        # bbox_from_radius()
+        assert False
+
+    def test_meters_travelled(self):
+        # meters_travelled()
+        assert False
+
+    def test_build_diff_query(self):
+        # build_diff_query()
+        assert False
+
+    def test_get_geom_from_item(self):
+        # get_geom_from_item()
+        assert False

--- a/dap_api/app/app/tests/backend/test_ors_processor.py
+++ b/dap_api/app/app/tests/backend/test_ors_processor.py
@@ -1,0 +1,73 @@
+import json
+
+import pytest
+from sqlalchemy.orm import Session
+
+from app.backend.ors_processor import ORSProcessor, result_key
+from app.schemas import PathOptions, ORSRequest
+from app.tests.backend.util_test_data import update_info_set_1, update_info_set_2, calc_features_set_1, \
+    calc_features_set_2, matching_iso_set_1, matching_iso_set_2, calc_features_set_3, \
+    calc_features_set_4, calc_features_set_5, basic_options
+
+
+class TestOrsProcessor:
+    @pytest.mark.skipif(True, reason="TODO")  # TODO: WIP
+    def test_handle_ors_request(self):
+        assert False
+
+    @pytest.mark.parametrize(
+        "options,request_dict,response,response_no_avoid,out", [
+            calc_features_set_1(),
+            calc_features_set_2(),
+            calc_features_set_3(),
+            calc_features_set_4(),
+            calc_features_set_5()
+
+        ]
+    )
+    def test_calculate_new_features(self, db: Session, options: PathOptions, request_dict, response, response_no_avoid,
+                                    out):
+        f = ORSProcessor.calculate_new_features(db, options, request_dict, response, response_no_avoid)
+        assert f == out
+
+    @pytest.mark.parametrize(
+        "avoid_results,item,out", [
+            matching_iso_set_1(),
+            matching_iso_set_2()
+        ]
+    )
+    def test_get_matching_isochrone(self, avoid_results, item, out):
+        n = ORSProcessor.get_matching_isochrone(avoid_results, item)
+        assert n == out
+
+    @pytest.mark.parametrize(
+        "item,avoid_item,options,request_dict,out",
+        [
+            update_info_set_1(),
+            update_info_set_2()
+
+        ])
+    def test_update_info(self, item, avoid_item, options: PathOptions, request_dict: ORSRequest, out):
+        ORSProcessor.update_info(avoid_item, item, options, request_dict)
+        assert json.dumps(avoid_item) == json.dumps(out)
+
+    @pytest.mark.skipif(True, reason="TODO")  # TODO: WIP
+    def test_get_bounding_box(self):
+        assert False
+
+    @pytest.mark.skipif(True, reason="TODO")  # TODO: WIP
+    def test_fix_bbox(self):
+        assert False
+
+    @pytest.mark.skipif(True, reason="TODO")  # TODO: WIP
+    def test_prepare_request_dic(self):
+        assert False
+
+    @pytest.mark.skipif(True, reason="TODO")  # TODO: WIP
+    def test_prepare_headers(self):
+        assert False
+
+
+def test_result_keys():
+    assert result_key(basic_options(res="json")) == "routes"
+    assert result_key(basic_options()) == "features"

--- a/dap_api/app/app/tests/backend/util_test_data.py
+++ b/dap_api/app/app/tests/backend/util_test_data.py
@@ -1,0 +1,221 @@
+"""
+Objects used to parametrize tests.
+These are functions as some objects are altered.
+To keep the pytest output correct, pass a copy of the object to the test set instead.
+"""
+from app.schemas import PathOptions
+from typing import Union
+
+
+def basic_directions_geojson_item(
+        dis: Union[int, float] = 5,
+        dur: Union[int, float] = 5,
+        geom: Union[dict, None] = None) -> dict:
+    if geom is None:
+        geom = {"dummy": "dummy"}
+    return {
+        "bbox": [0, 3, 0, 3],
+        "type": "Feature",
+        "properties": {
+            "segments": "dummy",
+            "summary": {"distance": dis, "duration": dur},
+            "way_points": "dummy"},
+        "geometry": geom
+    }
+
+
+def basic_isochrones_item(
+        g_id: Union[int, float] = 0,
+        val: Union[int, float] = 200.0,
+        geom: Union[dict, None] = None,
+        a: Union[int, float] = 4,
+        p: Union[int, float] = 50) -> dict:
+    if geom is None:
+        geom = {"dummy": "dummy"}
+    return {
+        "type": "Feature",
+        "properties": {
+            "group_index": g_id,
+            "value": val,
+            "center": [
+                8.6814962950468,
+                49.41460087012079
+            ],
+            "area": a,
+            "total_pop": p
+        },
+        "geometry": geom
+    }
+
+
+def basic_options(api: str = "directions", res: str = "geojson") -> PathOptions:
+    return PathOptions.parse_obj({
+        "portal_mode": "avoid_areas",
+        "ors_api": api,
+        "ors_profile": "driving-car",
+        "ors_response_type": res
+    })
+
+
+def update_info_set_1() -> tuple:
+    """directions diff on distance and duration"""
+    return (
+        basic_directions_geojson_item(),
+        basic_directions_geojson_item(dis=8, dur=15),
+        basic_options(), {
+            "attributes": []
+        }, {
+            "bbox": [0, 3, 0, 3], "type": "Feature", "properties": {
+                "summary": {"distance": 3, "duration": 10}},
+            "geometry": {"dummy": "dummy"}
+        }
+    )
+
+
+def update_info_set_2() -> tuple:
+    """float values are rounded"""
+    return (
+        basic_directions_geojson_item(dis=5.11111, dur=5.11111),
+        basic_directions_geojson_item(dis=8, dur=15),
+        basic_options(), {
+            "attributes": []
+        }, {
+            "bbox": [0, 3, 0, 3], "type": "Feature", "properties": {
+                "summary": {"distance": 2.9, "duration": 9.9}},
+            "geometry": {"dummy": "dummy"}
+        }
+    )
+
+
+def calc_features_set_1() -> tuple:
+    d_a = basic_directions_geojson_item(dis=8, dur=15, geom={"coordinates": [[0, 0], [1, 1], [1, 2], [2, 2], [3, 3]],
+                                                             "type": "LineString"})
+    d = basic_directions_geojson_item(geom={"coordinates": [[0, 0], [3, 3]], "type": "LineString"})
+    return (
+        basic_options(res="geojson"), {
+            "attributes": []
+        },
+        [d_a],
+        [d],
+        [{
+            "bbox": [0, 3, 0, 3], "type": "Feature", "properties": {
+                "summary": {"distance": 3, "duration": 10}},
+            "geometry": {'bbox': [1.0, 1.0, 2.0, 2.0],
+                         "coordinates": [[1, 1], [1, 2], [2, 2]],
+                         "type": "LineString"}
+        }]
+    )
+
+
+def calc_features_set_2() -> tuple:
+    """directions no diff"""
+    d = basic_directions_geojson_item()
+    d['geometry'] = {"coordinates": [[0, 0], [3, 3]], "type": "LineString"}
+    return (
+        basic_options(res="geojson"), {
+            "attributes": []
+        },
+        [d],
+        [d],
+        []
+    )
+
+
+def calc_features_set_3() -> tuple:
+    """isochrones no diff"""
+    i = basic_isochrones_item()
+    return (
+        basic_options(api="isochrones"),
+        {
+            "attributes": ["total_pop", "area"]
+        },
+        [i],
+        [i],
+        []
+    )
+
+
+def calc_features_set_4() -> tuple:
+    """isochrones single diff"""
+    i = basic_isochrones_item(geom={"coordinates": [[[0, 0], [2, 0], [2, 2], [0, 2], [0, 0]]], "type": "Polygon"})
+    i_avoid = basic_isochrones_item(geom={"coordinates": [[[0, 1], [0, 2], [2, 2], [2, 1], [0, 1]]], "type": "Polygon"},
+                                    a=2, p=20)
+    return (
+        basic_options(api="isochrones"),
+        {
+            "attributes": ["total_pop", "area"]
+        },
+        [i_avoid],
+        [i],
+        [basic_isochrones_item(
+            geom={"bbox": [0.0, 0.0, 2.0, 1.0], "coordinates": [[[0, 1], [2, 1], [2, 0], [0, 0], [0, 1]]],
+                  "type": "Polygon"}, a=2, p=30)]
+    )
+
+
+def calc_features_set_5() -> tuple:
+    """isochrones multi-range diff with multi polygon output"""
+    i = basic_isochrones_item(
+        geom={"coordinates": [[[0, 0], [2, 2], [2, 0], [0, 0]]], "type": "Polygon"})
+    i_avoid = basic_isochrones_item(
+        geom={"coordinates": [[[0, 0], [1, 1], [2, 0], [0, 0]]], "type": "Polygon"},
+        a=2,
+        p=20)
+    i2 = basic_isochrones_item(
+        val=400.0,
+        a=10,
+        p=200,
+        geom={"coordinates": [[[0, 0], [4, 0], [4, 4], [0, 4], [0, 0]]], "type": "Polygon"})
+    i_avoid2 = basic_isochrones_item(
+        val=400.0,
+        geom={"coordinates": [[[0, 1], [3, 4], [4, 4], [4, 3], [1, 0], [0, 0], [0, 1]]], "type": "Polygon"},
+        a=4,
+        p=120)
+    return (
+        basic_options(api="isochrones"),
+        {
+            "attributes": ["total_pop", "area"]
+        },
+        [i_avoid, i_avoid2],
+        [i, i2],
+        [
+            basic_isochrones_item(
+                geom={"bbox": [1.0, 0.0, 2.0, 2.0], "coordinates": [[[1, 1], [2, 2], [2, 0], [1, 1]]],
+                      "type": "Polygon"}, a=2, p=30),
+            basic_isochrones_item(
+                val=400.0,
+                a=6,
+                p=80,
+                geom={"bbox": [0.0, 0.0, 4.0, 4.0], "coordinates": [[[[0, 4], [3, 4], [0, 1], [0, 4]]],
+                                                                    [[[4, 0], [1, 0], [4, 3], [4, 0]]]],
+                      "type": "MultiPolygon"
+                      }
+            )
+        ]
+    )
+
+
+def matching_iso_set_1() -> tuple:
+    """isochrone match"""
+    return (
+        [
+            basic_isochrones_item(),
+            basic_isochrones_item(val=400.0),
+            basic_isochrones_item(g_id=1),
+            basic_isochrones_item(g_id=1, val=400.0)
+        ],
+        {"properties": {"group_index": 1, "value": 400.0}},
+        basic_isochrones_item(g_id=1, val=400.0)
+    )
+
+
+def matching_iso_set_2() -> tuple:
+    """no isochrone match"""
+    return (
+        [
+            basic_isochrones_item(),
+            basic_isochrones_item(val=400.0),
+        ],
+        {"properties": {"group_index": 1, "value": 200.0}},
+        None
+    )

--- a/dap_api/app/app/tests/utils/utils.py
+++ b/dap_api/app/app/tests/utils/utils.py
@@ -2,6 +2,8 @@ import random
 import string
 from typing import Dict, List
 
+from pydantic import EmailStr
+
 from app.config import settings
 
 
@@ -9,8 +11,8 @@ def random_lower_string(length: int = 32) -> str:
     return "".join(random.choices(string.ascii_lowercase, k=length))
 
 
-def random_email() -> str:
-    return f"{random_lower_string(12)}@{random_lower_string(4)}.com"
+def random_email() -> EmailStr:
+    return EmailStr(f"{random_lower_string(12)}@{random_lower_string(4)}.com")
 
 
 def random_coordinate(min_value: int, max_value: int) -> List[float]:


### PR DESCRIPTION
Adds boolean `generate_difference` to `portal_options` for the ors_api POST endpoints.

Passing `true` consumes 2 ors requests and internally sends one request with the stored avoid areas and one without.
The geometric difference is calculated, relevant metrics recaclulated and irrelevant attributes dropped.
The result is returned in either `geojson` format or `json` for directions only. `gpx` is not supported.

Closes https://github.com/GIScience/heigit-disaster-portal/issues/12