### PR TITLE
build(docker): improve healthcheck & dependency

### DIFF
--- a/docker-compose.reload.yml
+++ b/docker-compose.reload.yml
@@ -5,7 +5,8 @@ services:
     container_name: dap-api-reload
     image: disaster-area-portal-dev
     depends_on:
-      - dap-db
+      dap-db:
+        condition: service_healthy
     build:
       context: .
       dockerfile: ./dap_api/Dockerfile
@@ -33,7 +34,7 @@ services:
     environment:
       - PGDATA=/var/lib/postgresql/data/pgdata
     healthcheck:
-      test: [ "CMD-SHELL", "pg_isready" ]
+      test: [ "CMD-SHELL", "pg_isready -d ${POSTGRES_DB} -U ${POSTGRES_USER}"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,8 @@ services:
     image: disaster-area-portal
     restart: "unless-stopped"
     depends_on:
-      - dap-db
+      dap-db:
+        condition: service_healthy
     build:
       context: .
       dockerfile: ./dap_api/Dockerfile
@@ -35,7 +36,7 @@ services:
     environment:
       - PGDATA=/var/lib/postgresql/data/pgdata
     healthcheck:
-      test: [ "CMD-SHELL", "pg_isready" ]
+      test: [ "CMD-SHELL", "pg_isready -d ${POSTGRES_DB} -U ${POSTGRES_USER}"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
compose was already starting the api container when the db was started but not ready, resulting in some unnecessary connection failures.
It now properly waits until the DB is ready to accept connections.

Previously the DB container logs were spammed with FATAL errors: role "root" does not exist.
This is fixed after doing the healthcheck with specified DB and user.